### PR TITLE
Removes a printf in etcd_get_one

### DIFF
--- a/etcd-api.c
+++ b/etcd-api.c
@@ -245,7 +245,6 @@ etcd_get_one (_etcd_session *session, char *key, etcd_server *srv, char *prefix,
                      srv->host,srv->port,prefix,key) < 0) {
                 goto *err_label;
         }
-        printf("url = %s\n",url);
         err_label = &&free_url;
 
         curl = curl_easy_init();


### PR DESCRIPTION
Was this line supposed to be left in? It looks like it was for debugging purposes.
